### PR TITLE
Add option to cancel a job

### DIFF
--- a/components/TactileItem.vue
+++ b/components/TactileItem.vue
@@ -4,22 +4,24 @@
       <h2> {{ meta.title }}</h2>
       <p> {{ meta.format }} <em v-if="meta.author"> von {{ meta.author }} </em> </p>
     </div>
-    <div
-      v-if="status === 'draft'"
-      class="actions" >
+    <div class="actions" >
       <TactileButton
+        v-if="status === 'draft'"
         icon="edit"
         icon-position="right"
-        @click="$emit('edit')"
-      >
+        @click="$emit('edit')" >
         Bearbeiten
       </TactileButton>
       <TactileButton
         icon="trash"
         icon-position="right"
-        @click="$emit('delete')"
-      >
-        Löschen
+        @click="$emit('delete')" >
+        <div v-if="status === 'draft'">
+          Löschen
+        </div>
+        <div v-if="status === 'ordered'">
+          Stornieren
+        </div>
       </TactileButton>
     </div>
   </div>


### PR DESCRIPTION
If you clicked on "Produktion starten" before, there was no way to get rid of the current job. Ie. you couldn't start over again. Now, if you clicked on "Produktion starten" you have to "cancel" the ordered item (that will remove it) and start a new one.