### PR TITLE
92 about link footer

### DIFF
--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -29,6 +29,7 @@ $grid-max-width: 960px;
  * COLORS
  */
 $color-text: #333;
+$color-text-light: #666;
 $color-bg: #eee;
 $color-brand: #d9007d;
 $color-white: #fff;

--- a/components/TactileFooter.vue
+++ b/components/TactileFooter.vue
@@ -1,0 +1,35 @@
+<template>
+  <footer>
+    <div class="wrapper">
+      <ul>
+        <li><a href="https://tactile.news/">Über tactile.news</a></li>
+      </ul>
+    </div>
+  </footer>
+</template>
+
+<style lang="scss" scoped>
+@import '~assets/styles/variables';
+
+.wrapper {
+  margin: auto;
+  padding: $spacing-small 0;
+  max-width: $grid-max-width;
+  text-align: center;
+}
+
+ul {
+  list-style: none;
+}
+
+li {
+  display: inline-block;
+}
+
+a {
+  padding: $spacing-small;
+  font-size: $font-size-small;
+  color: $color-text-light;
+  text-decoration: none;
+}
+</style>

--- a/components/TactileNav.vue
+++ b/components/TactileNav.vue
@@ -2,9 +2,6 @@
   <nav>
     <ul>
       <li><nuxt-link to="/guide">Schnellstart</nuxt-link></li>
-      <a
-        href="http://tactile.news"
-        target="_blank">Über tactile.news</a>
       <li><nuxt-link to="/">Dashboard</nuxt-link></li>
     </ul>
   </nav>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,14 +2,17 @@
   <div>
     <tactile-header />
     <nuxt class="wrapper" />
+    <tactile-footer />
   </div>
 </template>
 
 <script>
 import TactileHeader from '~/components/TactileHeader.vue'
+import TactileFooter from '~/components/TactileFooter.vue'
 export default {
   components: {
-    TactileHeader
+    TactileHeader,
+    TactileFooter
   }
 }
 </script>
@@ -19,7 +22,7 @@ export default {
 
 .wrapper {
   max-width: $grid-max-width;
-  margin: $spacing-unit auto;
+  margin: $spacing-unit auto 0;
   background: #fff;
 }
 </style>


### PR DESCRIPTION
### Changes

* Der Link »Über tactile.news« wird nicht mehr im Seitenkopf sondern im Seitenfuß angezeigt.

### To do

* [ ] Use color variables in SCSS

### Dependencies

* Merge #107, #111 

***

<img width="1018" alt="bildschirmfoto 2019-01-12 um 16 33 10" src="https://user-images.githubusercontent.com/1512805/51075553-40826d00-168d-11e9-9500-7cfa9ccf3620.png">

***

Close #92 